### PR TITLE
Fix fallthrough panic bug

### DIFF
--- a/src/boolify.rs
+++ b/src/boolify.rs
@@ -28,24 +28,22 @@ pub fn boolify(arith_circuit: &BristolCircuit, bit_width: usize) -> BristolCircu
             } else if input.type_ == "bool" {
                 1
             } else {
-                panic!("Unsupported input type: {}", input.type_)
+                panic!("Unsupported input type: {:?}", input.type_)
             },
             &id_gen,
         ));
     }
 
     for const_info in &arith_circuit.info.constants {
-        if let Some(v) = const_info.value.as_u64() {
+        if let Some(v) = const_info.value.as_f64() {
             wires[const_info.address] =
                 Some(ValueWire::new_const(v as usize, &id_gen).resize(bit_width));
-        }
-
-        if let Some(v) = const_info.value.as_bool() {
+        } else if let Some(v) = const_info.value.as_bool() {
             wires[const_info.address] =
                 Some(ValueWire::new_const(if v { 1 } else { 0 }, &id_gen).resize(1));
+        } else {
+            panic!("Unsupported type: {:?}", const_info.value);
         }
-
-        panic!("Unsupported type: {}", const_info.value);
     }
 
     let unary_ops = ["AUnaryAdd", "AUnarySub", "ANot", "ABitNot"]


### PR DESCRIPTION
## What is this PR doing?

Fixes simple (silly) bug where constants would always fall through to panic even when they are handled correctly.

## How can these changes be manually tested?

Boolify a circuit that includes a constant (see cli instructions in readme)

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist
- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
